### PR TITLE
Trust original line breaks from SSH

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/SSHSite.java
+++ b/src/main/java/org/jvnet/hudson/plugins/SSHSite.java
@@ -134,7 +134,7 @@ public class SSHSite {
 					int i = in.read(tmp, 0, 1024);
 					if (i < 0)
 						break;
-					logger.println(new String(tmp, 0, i));
+					logger.print(new String(tmp, 0, i));
 				}
 				if (channel.isClosed()) {
 					status = channel.getExitStatus();


### PR DESCRIPTION
Trust original line breaks from SSH, instead of forcing a line break every 1024 bytes.

This causes trouble when there is a need to parse the log. Parsing does not behave as expected because of the line breaks in the middle of actual lines returned by ssh.
Here is an example output by SSH plugin (notice the split in the middle of line 8): https://gist.github.com/c9de942c162438d6edf6 
