### PR TITLE
Fix JENKINS-19811. Change JSCH version to 0.1.51.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@ Based on the cool scp plugin.</description>
 	<parent>
 		<groupId>org.jenkins-ci.plugins</groupId>
 		<artifactId>plugin</artifactId>
-		<version>1.596</version>
+		<version>1.424</version>
 	</parent>
 
 	<artifactId>ssh</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@ Based on the cool scp plugin.</description>
 	<parent>
 		<groupId>org.jenkins-ci.plugins</groupId>
 		<artifactId>plugin</artifactId>
-		<version>1.424</version>
+		<version>1.596</version>
 	</parent>
 
 	<artifactId>ssh</artifactId>
@@ -26,7 +26,7 @@ Based on the cool scp plugin.</description>
 		<dependency>
 			<groupId>com.jcraft</groupId>
 			<artifactId>jsch</artifactId>
-			<version>0.1.42</version>
+			<version>0.1.51</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
Seems to work just fine (tested on a fresh install of Jenkins 1.595). I hope a release can be available soon for this fix.

Thanks,
Eric.