### PR TITLE
Fix for JENKINS-10128

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/SSHBuildWrapper.java
+++ b/src/main/java/org/jvnet/hudson/plugins/SSHBuildWrapper.java
@@ -182,6 +182,13 @@ public final class SSHBuildWrapper extends BuildWrapper {
 			return true;
 		}
 
+		public FormValidation doCheckSiteName(@QueryParameter final String value) {
+			if ((value == null) || (value.trim().isEmpty())) {
+				return FormValidation.error("SSH Site not specified");
+			}
+			return FormValidation.ok();
+		}
+
 		public FormValidation doKeyfileCheck(@QueryParameter String keyfile) {
 			keyfile = Util.fixEmpty(keyfile);
 			if (keyfile != null) {

--- a/src/main/java/org/jvnet/hudson/plugins/SSHBuildWrapper.java
+++ b/src/main/java/org/jvnet/hudson/plugins/SSHBuildWrapper.java
@@ -66,6 +66,10 @@ public final class SSHBuildWrapper extends BuildWrapper {
 	private boolean executePreBuildScript(AbstractBuild<?, ?> build, BuildListener listener) throws IOException, InterruptedException {
 		PrintStream logger = listener.getLogger();
 		SSHSite site = getSite();
+		if (site == null) {
+			listener.getLogger().printf("[SSH] No SSH site specified%n");
+			return false;
+		}
 		Map<String, String> vars = new HashMap<String, String>();
 		vars.putAll(build.getEnvironment(listener));
 		vars.putAll(build.getBuildVariables());
@@ -80,6 +84,10 @@ public final class SSHBuildWrapper extends BuildWrapper {
 	private boolean executePostBuildScript(AbstractBuild<?, ?> build, BuildListener listener) throws IOException, InterruptedException {
 		PrintStream logger = listener.getLogger();
 		SSHSite site = getSite();
+		if (site == null) {
+			listener.getLogger().printf("[SSH] No SSH site specified%n");
+			return false;
+		}
 		Map<String, String> vars = new HashMap<String, String>();
 		vars.putAll(build.getEnvironment(listener));
 		vars.putAll(build.getBuildVariables());
@@ -109,7 +117,6 @@ public final class SSHBuildWrapper extends BuildWrapper {
 
 	public SSHSite getSite() {
 		SSHSite[] sites = DESCRIPTOR.getSites();
-
 		for (SSHSite site : sites) {
 			if (site.getSitename().equals(siteName))
 				return site;

--- a/src/main/java/org/jvnet/hudson/plugins/SSHBuilder.java
+++ b/src/main/java/org/jvnet/hudson/plugins/SSHBuilder.java
@@ -7,9 +7,11 @@ import hudson.model.AbstractProject;
 import hudson.model.BuildListener;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Builder;
+import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import net.sf.json.JSONObject;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 
 import java.io.IOException;
@@ -120,6 +122,13 @@ public class SSHBuilder extends Builder {
 				m.add(site.getSitename());
 			}
 			return m;
+		}
+
+		public FormValidation doCheckSiteName(@QueryParameter final String value) {
+			if ((value == null) || (value.trim().isEmpty())) {
+				return FormValidation.error("SSH Site not specified");
+			}
+			return FormValidation.ok();
 		}
 	}
 }

--- a/src/main/java/org/jvnet/hudson/plugins/SSHBuilder.java
+++ b/src/main/java/org/jvnet/hudson/plugins/SSHBuilder.java
@@ -62,16 +62,19 @@ public class SSHBuilder extends Builder {
 	@Override
 	public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
 		SSHSite site = getSite();
-		
+		if (site == null) {
+			listener.getLogger().printf("[SSH] No SSH site specified%n");
+			return false;
+		}
 		// Get the build variables and make sure we substitute the current SSH Server host name
 		site.setResolvedHostname(build.getEnvironment(listener).expand(site.getHostname()));
-		
+
 		Map<String, String> vars = new HashMap<String, String>(); 
 		vars.putAll(build.getEnvironment(listener));
 		vars.putAll(build.getBuildVariables());
 		String runtime_cmd = VariableReplacerUtil.replace(command, vars);
 
-		if (site != null && runtime_cmd != null && runtime_cmd.trim().length() > 0) {
+		if (runtime_cmd != null && runtime_cmd.trim().length() > 0) {
 			if (execEachLine) {
 				listener.getLogger().printf("[SSH] commands:%n%s%n", runtime_cmd);
 			}


### PR DESCRIPTION
This PR addresses https://issues.jenkins-ci.org/browse/JENKINS-10128, NullPointerException when no SSH site is specified in the job configuration.

These changes add better failure when an SSH site has not been specified, specifically a console log entry and job failure instead of a NPE.

Some basic form validation has also been added that causes a message to be displayed when a site has not been selected:
![ssh_plugin-ssh_site_validation-01](https://cloud.githubusercontent.com/assets/12058089/8015465/450251a4-0b9e-11e5-806d-f1c8d6b6bf0f.jpg)
