### PR TITLE
This commit addresses https://issues.jenkins-ci.org/browse/JENKINS-24913

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/SSHBuildWrapper.java
+++ b/src/main/java/org/jvnet/hudson/plugins/SSHBuildWrapper.java
@@ -74,7 +74,7 @@ public final class SSHBuildWrapper extends BuildWrapper {
 		vars.putAll(build.getEnvironment(listener));
 		vars.putAll(build.getBuildVariables());
 		String runtime_cmd = VariableReplacerUtil.replace(preScript, vars);
-		log(logger, "executing pre build script:\n" + runtime_cmd);
+		log(logger, "executing pre build script:\n" + VariableReplacerUtil.scrub(runtime_cmd, vars, build.getSensitiveBuildVariables()));
 		if (runtime_cmd != null && !runtime_cmd.trim().equals("")) {
 			return site.executeCommand(logger, runtime_cmd) == 0;
 		}
@@ -92,7 +92,7 @@ public final class SSHBuildWrapper extends BuildWrapper {
 		vars.putAll(build.getEnvironment(listener));
 		vars.putAll(build.getBuildVariables());
 		String runtime_cmd = VariableReplacerUtil.replace(postScript, vars);
-		log(logger, "executing post build script:\n" + runtime_cmd);
+		log(logger, "executing post build script:\n" + VariableReplacerUtil.scrub(runtime_cmd, vars, build.getSensitiveBuildVariables()));
 		if (runtime_cmd != null && !runtime_cmd.trim().equals("")) {
 			return site.executeCommand(logger, runtime_cmd) == 0;
 		}

--- a/src/main/java/org/jvnet/hudson/plugins/SSHBuilder.java
+++ b/src/main/java/org/jvnet/hudson/plugins/SSHBuilder.java
@@ -75,15 +75,16 @@ public class SSHBuilder extends Builder {
 		vars.putAll(build.getEnvironment(listener));
 		vars.putAll(build.getBuildVariables());
 		String runtime_cmd = VariableReplacerUtil.replace(command, vars);
+		String scrubbed_cmd = VariableReplacerUtil.scrub(runtime_cmd, vars, build.getSensitiveBuildVariables());
 
 		if (runtime_cmd != null && runtime_cmd.trim().length() > 0) {
 			if (execEachLine) {
-				listener.getLogger().printf("[SSH] commands:%n%s%n", runtime_cmd);
+				listener.getLogger().printf("[SSH] commands:%n%s%n", scrubbed_cmd);
 			}
 			else {
-				listener.getLogger().printf("[SSH] script:%n%s%n", runtime_cmd);
+				listener.getLogger().printf("[SSH] script:%n%s%n", scrubbed_cmd);
 			}
-			listener.getLogger().printf("%n[SSH] executing...%n", runtime_cmd);
+			listener.getLogger().printf("%n[SSH] executing...%n");
 			return site.executeCommand(listener.getLogger(), runtime_cmd, execEachLine) == 0;
 		}
 		return true;

--- a/src/main/java/org/jvnet/hudson/plugins/VariableReplacerUtil.java
+++ b/src/main/java/org/jvnet/hudson/plugins/VariableReplacerUtil.java
@@ -1,6 +1,7 @@
 package org.jvnet.hudson.plugins;
 
 import java.util.Map;
+import java.util.Set;
 
 public class VariableReplacerUtil {
 	public static String replace(String originalCommand, Map<String, String> vars) {
@@ -17,5 +18,27 @@ public class VariableReplacerUtil {
 		sb.append("\n");
 		sb.append(originalCommand);
 		return sb.toString();
+	}
+
+	public static String scrub(String command, Map<String, String> vars, Set<String> eyesOnlyVars) {
+		if(command == null || vars == null || eyesOnlyVars == null){
+			return command;
+		}
+		vars.remove("_");
+		for (String sensitive : eyesOnlyVars) {
+			for (String variable : vars.keySet()) {
+				if (variable.equals(sensitive)) {
+					String value = vars.get(variable);
+					if (command.contains(value)) {
+						if (command.contains("\"" + value + "\"")) {
+							command = command.replace(("\"" + value + "\"") , "**********");
+						}
+						command = command.replace(value , "**********");
+					}
+					break;
+				}
+			}
+		}
+		return command;
 	}
 }


### PR DESCRIPTION
Added a method to scrub the runtime command to VariableReplacerUtil.

It probably would have been easier to just replace *runtime_cmd* with *command*, but I think it is better to have a scrubbed version of *runtime_cmd* because it more accurately reflects what is actually being passed over SSH.

Test Job Configuration:
![ssh-plugin-showing_passwords-03](https://cloud.githubusercontent.com/assets/12058089/8146131/1859d572-11ee-11e5-9666-3186644363d9.jpg)

Before Changes:
![ssh-plugin-showing_passwords-01](https://cloud.githubusercontent.com/assets/12058089/8146132/2f962894-11ee-11e5-8304-653a78fd4473.jpg)

After Changes:
![ssh-plugin-showing_passwords-04](https://cloud.githubusercontent.com/assets/12058089/8146134/39f25c22-11ee-11e5-93b3-be338d5a698b.jpg)


