### PR TITLE
[JENKINS-74031] Migrate legacy checkUrl attributes in `SSHBuildWrapper/global.jelly`

### DIFF
--- a/src/main/resources/org/jvnet/hudson/plugins/SSHBuildWrapper/global.jelly
+++ b/src/main/resources/org/jvnet/hudson/plugins/SSHBuildWrapper/global.jelly
@@ -7,14 +7,14 @@
       <f:repeatable var="site" name="sites" items="${descriptor.sites}">
         <table width="100%">
           <f:entry title="${%Hostname}" help="/plugin/ssh/help-hostname.html">
-            <f:textbox name="hostname" value="${site.hostname}" checkUrl="'${rootURL}/descriptorByName/org.jvnet.hudson.plugins.SSHBuildWrapper/checkHostname?hostname='+escape(this.value)" />
+            <f:textbox name="hostname" value="${site.hostname}" field="hostname" />
           </f:entry>
           <f:entry title="${%Port}" help="/plugin/ssh/help-port.html">
             <f:textbox name="port" value="${site.port}"/>
           </f:entry>
 
           <f:entry title="${%Credentials}">
-            <c:select name="credentialId" field="credentialId" value="${site.credentialId}" checkUrl="'${rootURL}/descriptorByName/org.jvnet.hudson.plugins.SSHBuildWrapper/checkCredentialId?credentialId='+escape(this.value)" />
+            <c:select name="credentialId" field="credentialId" value="${site.credentialId}" />
           </f:entry>
 
           <f:entry title="${%Pty}" help="/plugin/ssh/help-pty.html">


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

[JENKINS-74031](https://issues.jenkins.io/browse/JENKINS-74031)

Similar to https://github.com/jenkinsci/subversion-plugin/pull/319 - stapler already binds these check methods to their respective field names. Requests are correctly sent to server for validation after changes. 

### Testing done

[Before changes](https://www.loom.com/share/5d55d22a16e54632891bc5e67abe9054)
[After changes](https://www.loom.com/share/9f40b5e98efa4320a663655981826d21)

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
